### PR TITLE
ims Step6

### DIFF
--- a/src/main/java/codesquad/domain/issue/Comment.java
+++ b/src/main/java/codesquad/domain/issue/Comment.java
@@ -29,6 +29,9 @@ public class Comment extends AbstractEntity {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_comment_issue"))
     private Issue issue;
 
+    @OneToOne        //(cascade = CascadeType.ALL) 하면 PersistentObjectException: detached entity passed to persist: codesquad.domain.issue.File]
+    private File file;
+
     private boolean deleted = false;
 
     public Comment() {
@@ -74,6 +77,14 @@ public class Comment extends AbstractEntity {
 
     public void setIssue(Issue issue) {
         this.issue = issue;
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public void setFile(File file) {
+        this.file = file;
     }
 
     public boolean isOwner(User loginUser) {

--- a/src/main/java/codesquad/domain/issue/Comment.java
+++ b/src/main/java/codesquad/domain/issue/Comment.java
@@ -29,7 +29,8 @@ public class Comment extends AbstractEntity {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_comment_issue"))
     private Issue issue;
 
-    @OneToOne        //(cascade = CascadeType.ALL) 하면 PersistentObjectException: detached entity passed to persist: codesquad.domain.issue.File]
+    @OneToOne        //(cascade = CascadeType.ALL) 하면 PersistentObjectException: detached entity passed to persist: codesquad.domain.issue.File] -->이미 db에 파일이 존재(키값 존재)하므로, comment가 생성될때, 똑같은 file 엔티티를 한번 더 저장하려고 해서 발생하는 에러.. 종속성 설정을 없앤다.
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_comment_file"))
     private File file;
 
     private boolean deleted = false;

--- a/src/main/java/codesquad/domain/issue/File.java
+++ b/src/main/java/codesquad/domain/issue/File.java
@@ -1,0 +1,100 @@
+package codesquad.domain.issue;
+
+import codesquad.domain.user.User;
+import support.domain.AbstractEntity;
+
+import javax.persistence.*;
+import java.util.Objects;
+
+@Entity
+public class File extends AbstractEntity {
+
+    @Column
+    private String originalName;
+
+    @Column
+    private String savedName;
+
+    @Column
+    private String location;
+
+    @ManyToOne
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_file_uploader"))
+    private User uploader;
+
+    @OneToOne(cascade = CascadeType.ALL)    //file의 commentId는 null인데,, 설정 어떻게
+    @JoinColumn(foreignKey = @ForeignKey(name = "fk_file_comment"))
+    private Comment comment;
+
+    public File() {
+    }
+
+    public File(String originalName, String savedName, String location, User uploader) {
+        this(0L, originalName, savedName, location, uploader);
+    }
+
+    public File(long id, String originalName, String savedName, String location, User uploader) {
+        super(id);
+        this.originalName = originalName;
+        this.savedName = savedName;
+        this.location = location;
+        this.uploader = uploader;
+    }
+
+    public String getOriginalName() {
+        return originalName;
+    }
+
+    public void setOriginalName(String originalName) {
+        this.originalName = originalName;
+    }
+
+    public String getSavedName() {
+        return savedName;
+    }
+
+    public void setSavedName(String savedName) {
+        this.savedName = savedName;
+    }
+
+    public User getUploader() {
+        return uploader;
+    }
+
+    public void setUploader(User uploader) {
+        this.uploader = uploader;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        if (!super.equals(o)) return false;
+        File file = (File) o;
+        return Objects.equals(originalName, file.originalName) &&
+                Objects.equals(savedName, file.savedName) &&
+                Objects.equals(uploader, file.uploader);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), originalName, savedName, uploader);
+    }
+
+    @Override
+    public String toString() {
+        return "File{" +
+                "originalName='" + originalName + '\'' +
+                ", savedName='" + savedName + '\'' +
+                ", uploader=" + uploader +
+                '}';
+    }
+}

--- a/src/main/java/codesquad/domain/issue/File.java
+++ b/src/main/java/codesquad/domain/issue/File.java
@@ -22,10 +22,6 @@ public class File extends AbstractEntity {
     @JoinColumn(foreignKey = @ForeignKey(name = "fk_file_uploader"))
     private User uploader;
 
-    @OneToOne(cascade = CascadeType.ALL)    //file의 commentId는 null인데,, 설정 어떻게
-    @JoinColumn(foreignKey = @ForeignKey(name = "fk_file_comment"))
-    private Comment comment;
-
     public File() {
     }
 

--- a/src/main/java/codesquad/domain/issue/FileRepository.java
+++ b/src/main/java/codesquad/domain/issue/FileRepository.java
@@ -1,0 +1,7 @@
+package codesquad.domain.issue;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FileRepository extends JpaRepository<File, Long> {
+
+}

--- a/src/main/java/codesquad/service/FileService.java
+++ b/src/main/java/codesquad/service/FileService.java
@@ -1,0 +1,46 @@
+package codesquad.service;
+
+import codesquad.UnAuthorizedException;
+import codesquad.domain.issue.File;
+import codesquad.domain.issue.FileRepository;
+import codesquad.domain.user.User;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+@Service
+public class FileService {
+
+    @Value("${file.path}")
+    private String uploadPath;
+
+    @Autowired
+    private FileRepository fileRepository;
+
+    @Transactional
+    public File upload(User loginUser, MultipartFile uploadedFile) throws IOException {
+        if (loginUser.isGuestUser()) throw new UnAuthorizedException("로그인이 필요 합니다.");
+        byte[] bytes = uploadedFile.getBytes();
+        Path path = Paths.get(uploadPath + uploadedFile.getResource().hashCode() + uploadedFile.getOriginalFilename());
+        Files.write(path, bytes);
+        File file = new File(uploadedFile.getOriginalFilename(), path.getFileName().toString(), path.toString(), loginUser);
+        return fileRepository.save(file);
+    }
+
+    public List<File> findAll() {
+        return fileRepository.findAll();
+    }
+
+    public File findFile(long id) {
+        return fileRepository.findById(id)
+                .orElseThrow(UnAuthorizedException::new);
+    }
+}

--- a/src/main/java/codesquad/service/IssueService.java
+++ b/src/main/java/codesquad/service/IssueService.java
@@ -86,7 +86,7 @@ public class IssueService {
         //loginUser가 필요한가?? 로그인 했는지 체크를 여기서 해야하는가?
         Issue currentIssue = issueRepository.findById(issueId).get();
         return currentIssue.setMilestone(milestoneRepository.findById(milestoneId).get());  //세터에서 return값을 받는게 맞는지, 아니면 void로 하고, 해당 이슈의 마이슬톤 게터를 리턴하게 하는 게 맞는지? 전자는 코드 수가 더 적은 장점이 있는데 세터가 리턴값이 존재하는게 맞는가?
-//        issueRepository.save(currentIssue);     //@Transactional를 하면 굳이 save할 필요가 없지 않음?? 그래도 해야하는게 맞을까??
+//        issueRepository.upload(currentIssue);     //@Transactional를 하면 굳이 save할 필요가 없지 않음?? 그래도 해야하는게 맞을까??
     }
 
     @Transactional
@@ -105,7 +105,7 @@ public class IssueService {
                 .orElseThrow(UnAuthorizedException::new));
     }
 
-    @Transactional  //얘 지정 하면 왜 자동 디비에 저장될까 --> 트랜잭션이 끝난 시점에 em의 플러쉬메소드가 실행되면서, 영속성컨텍스트에 있는 엔티티를 디비에 저장하는것임?(디비 어느 테이블인 줄 알고 저장시킴??) 안쓸 경우는 직접 레포지터리.save 해줘야함
+    @Transactional  //얘 지정 하면 왜 자동 디비에 저장될까 --> 트랜잭션이 끝난 시점에 em의 플러쉬메소드가 실행되면서, 영속성컨텍스트에 있는 엔티티를 디비에 저장하는것임?(디비 어느 테이블인 줄 알고 저장시킴??) 안쓸 경우는 직접 레포지터리.upload 해줘야함
     public Comment addComment(User loginUser, long issueId, Comment comment) {
         if (loginUser.isGuestUser()) throw new UnAuthorizedException("로그인이 필요합니다.");
         Issue currentIssue = issueRepository.findById(issueId)

--- a/src/main/java/codesquad/web/IssueController.java
+++ b/src/main/java/codesquad/web/IssueController.java
@@ -3,12 +3,10 @@ package codesquad.web;
 import codesquad.domain.user.User;
 import codesquad.dto.IssueDto;
 import codesquad.security.LoginUser;
-import codesquad.service.IssueService;
-import codesquad.service.LabelService;
-import codesquad.service.MilestoneService;
-import codesquad.service.UserService;
+import codesquad.service.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -31,6 +29,9 @@ public class IssueController {
 
     @Resource(name = "labelService")
     private LabelService labelService;
+
+    @Autowired
+    private FileService fileService;
 
     @GetMapping("/form")
     public String form(@LoginUser User loginUser) {
@@ -74,7 +75,7 @@ public class IssueController {
     public String setMilestone(@LoginUser User loginUser, @PathVariable long issueId, @PathVariable long milestoneId) {
         issueService.setMilestone(loginUser, issueId, milestoneId);
         log.debug("마일스톤 클릭!!!!!!!!!!!!!!!!!!!!!!!!!");
-        return "redirect:/issues/{issueId}";
+        return "redirect:/HissueId}";
     }
 
     @GetMapping("/{issueId}/setAssignee/{assigneeId}")

--- a/src/main/java/codesquad/web/api/ApiAttachmentController.java
+++ b/src/main/java/codesquad/web/api/ApiAttachmentController.java
@@ -30,18 +30,20 @@ public class ApiAttachmentController {
 
     @PostMapping("")
     public ResponseEntity upload(@LoginUser User loginUser, MultipartFile file) throws Exception {
+        log.debug("upload!!!!!!!!!!!!!!!!!!!!!");
         File uploadedFile = fileService.upload(loginUser, file);
         return new ResponseEntity<File>(uploadedFile, HttpStatus.OK);
     }
 
     @GetMapping("{id}")
     public ResponseEntity download(@LoginUser User loginUser, @PathVariable long id) throws IOException {
+        log.debug("download!!!!!!!!!!!!!!!!!!!");
         File file = fileService.findFile(id);
         Path path = Paths.get(file.getLocation());
         FileSystemResource resource = new FileSystemResource(path);
 
         HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.TEXT_XML);
+        headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         String encoredFilename = URLEncoder.encode(file.getOriginalName(), "UTF-8").replace("+", "%20");
         headers.set(HttpHeaders.CONTENT_DISPOSITION,
                 "attachment;filename=" + encoredFilename + ";filename*= UTF-8''" + encoredFilename);

--- a/src/main/java/codesquad/web/api/ApiAttachmentController.java
+++ b/src/main/java/codesquad/web/api/ApiAttachmentController.java
@@ -1,0 +1,51 @@
+package codesquad.web.api;
+
+import codesquad.domain.issue.File;
+import codesquad.domain.user.User;
+import codesquad.security.LoginUser;
+import codesquad.service.FileService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+@RestController
+@RequestMapping("/api/issues/{issueId}/attachments")
+public class ApiAttachmentController {
+    private static final Logger log = LoggerFactory.getLogger(ApiAttachmentController.class);
+
+    @Autowired
+    private FileService fileService;
+
+    @PostMapping("")
+    public ResponseEntity upload(@LoginUser User loginUser, MultipartFile file) throws Exception {
+        File uploadedFile = fileService.upload(loginUser, file);
+        return new ResponseEntity<File>(uploadedFile, HttpStatus.OK);
+    }
+
+    @GetMapping("{id}")
+    public ResponseEntity download(@LoginUser User loginUser, @PathVariable long id) throws IOException {
+        File file = fileService.findFile(id);
+        Path path = Paths.get(file.getLocation());
+        FileSystemResource resource = new FileSystemResource(path);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.TEXT_XML);
+        String encoredFilename = URLEncoder.encode(file.getOriginalName(), "UTF-8").replace("+", "%20");
+        headers.set(HttpHeaders.CONTENT_DISPOSITION,
+                "attachment;filename=" + encoredFilename + ";filename*= UTF-8''" + encoredFilename);
+        headers.setContentLength(resource.contentLength());
+        return new ResponseEntity<FileSystemResource>(resource, headers, HttpStatus.OK);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ handlebars.expose-session-attributes=true
 spring.devtools.livereload.enabled=true
 spring.devtools.restart.enabled=true
 spring.devtools.freemarker.cache=false
+
+file.path = C://Users//lollo//Desktop//uploadFile//
+spring.servlet.multipart.max-file-size=15MB

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -15,5 +15,5 @@ INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id
 INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id, writer_id) values (2, current_timestamp, current_timestamp, '해결되면 나한테 알려주고', false, 1, 1);
 INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id, writer_id) values (3, current_timestamp, current_timestamp, '내가 도와줄까요?', false, 1, 2);
 
-INSERT INTO file (id, create_date, modified_date, location, original_name, saved_name, comment_id, uploader_id) values (1, current_timestamp, current_timestamp, 'C:\Users\lollo\Desktop\uploadFile\0123456789sample.txt', 'sample.txt', '0123456789sample.txt', null, 1);
+INSERT INTO file (id, create_date, modified_date, location, original_name, saved_name, uploader_id) values (1, current_timestamp, current_timestamp, 'C:\Users\lollo\Desktop\uploadFile\0123456789sample.txt', 'sample.txt', '0123456789sample.txt', 1);
 

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -15,5 +15,5 @@ INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id
 INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id, writer_id) values (2, current_timestamp, current_timestamp, '해결되면 나한테 알려주고', false, 1, 1);
 INSERT INTO comment (id, create_date, modified_date, contents, deleted, issue_id, writer_id) values (3, current_timestamp, current_timestamp, '내가 도와줄까요?', false, 1, 2);
 
-
+INSERT INTO file (id, create_date, modified_date, location, original_name, saved_name, comment_id, uploader_id) values (1, current_timestamp, current_timestamp, 'C:\Users\lollo\Desktop\uploadFile\0123456789sample.txt', 'sample.txt', '0123456789sample.txt', null, 1);
 

--- a/src/main/resources/static/js/main.js
+++ b/src/main/resources/static/js/main.js
@@ -1,4 +1,5 @@
 console.log("main.js 시작");
+var fileData;   //업로드 파일 데이터
 
 //회원가입
 $("#join-submit").click(join);
@@ -103,6 +104,7 @@ function addComment(e){
     e.preventDefault();
     var json = new Object();
     json.contents = $("#comment").val();
+    json.file = fileData;
     var url = $("#add-comment").attr("action");
     console.log("url : " + url);
 
@@ -117,8 +119,14 @@ function addComment(e){
             console.log(data);
             console.log("writeOnly : " + data.formattedCreateDate);
             console.log("readOnly : " + data.formattedModifiedDate);
-            var commentTemplate = $("#write-comment-template").html();
-            var template = commentTemplate.format(data.writer.name, data.contents, data.issue.id, data.id, data.formattedCreateDate);
+            if(data.file) {
+                var commentTemplate = $("#write-comment-template").html();
+                var template = commentTemplate.format(data.writer.name, data.contents, data.issue.id, data.id, data.formattedCreateDate, data.file.originalName, data.file.id);
+            }
+            else {
+                var commentTemplate = $("#write-comment-template-no-upload-file").html();
+                var template = commentTemplate.format(data.writer.name, data.contents, data.issue.id, data.id, data.formattedCreateDate);
+            }
             $("#comments").append(template);
             $(".delete-comment-btn").click(deleteComment);
         }
@@ -198,6 +206,35 @@ function deleteComment(e) {
         error : onError,
         success : function(data, status, jqXHR) {
             deleteBtn.closest(".mdl-color-text--grey-700").remove();
+        }
+    })
+}
+
+//파일 첨부
+$(".upload-button").click(uploadFile);
+
+function uploadFile(e) {
+    e.preventDefault();
+    var uploadBtn = $(this);
+    var form = uploadBtn.closest("form")[0];
+    var formData = new FormData(form);
+
+    console.log("formData: " + formData);
+    var url = uploadBtn.closest("form").attr("action");
+    console.log("url : " + url);
+
+    $.ajax({
+        type : "post",
+        url : url,
+        data : formData,
+        processData : false,
+        contentType : false,
+        dataType : "json",
+        error : onError,
+        success : function(data, status, jqXHR) {
+            alert("파일이 업로드 되었습니다. 댓글 작성을 해주세요");
+            fileData = data;
+//            $("#write-comment-btn").click(addComment(e,data));    //이 방식으로 데이터 전달을 하면, 클릭 이벤트가 발생한 후, 메소드를 호출해야하는데 그냥 바로 호출해버림
         }
     })
 }

--- a/src/main/resources/templates/issue/show.html
+++ b/src/main/resources/templates/issue/show.html
@@ -95,7 +95,13 @@
                                 <span class="comment__author">
                                     <strong>
                                         <a>{{writer.name}}</a>
-                                        <span class="comment-contents">{{contents}}  {{formattedModifiedDate}}</span>
+                                        <br>
+                                        <span class="comment-contents">{{contents}}
+                                            {{#file}}
+                                            <a style="color: blue" href="/api/issues/{{issue.id}}/attachments/{{id}}"> [첨부 파일 : {{originalName}}] </a>
+                                            {{/file}}
+                                            &nbsp;{{formattedModifiedDate}}
+                                        </span>
                                     </strong>
                                 </span>
                                 <li>
@@ -117,10 +123,10 @@
                     {{/comments}}
                     <!-- comments end -->
                 </div>
-                <form action="/issue/1/uploadFile" enctype="multipart/form-data" method="POST">
+                <form action="/api/issues/{{id}}/attachments" enctype="multipart/form-data" method="POST">
                     <div style="margin:10px;">
                         <input type="file" name="file" id="file"/>
-                        <button class="mdl-button" type="submit">upload file</button>
+                        <button class="upload-button" type="submit">upload file</button>
                     </div>
                 </form>
                 <div class="mdl-color-text--primary-contrast mdl-card__supporting-text new-comment">
@@ -155,7 +161,41 @@
                 <span class="comment__author">
                     <strong>
                         <a>{0}</a>
-                        <span class="comment-contents">{1}          {4}</span>
+                        <br>
+                        <span class="comment-contents">{1}
+                            <a style="color: blue" href="/api/issues/{2}/attachments/{6}">[첨부 파일 : {5}]</a>
+                            &nbsp;{4}
+                        </span>
+                    </strong>
+                </span>
+                <li>
+                    <form style="display: inline;" action="/api/issues/{2}/comments/{3}" class="edit-comment" method="get">
+                        <button type="submit" class="edit-comment-btn">edit</button>
+                    </form>
+                </li>
+                <li>
+                    <form style="display: inline;" action="/api/issues/{2}/comments/{3}" class="delete-comment" method="post">
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button type="submit" class="delete-comment-btn">delete</button>
+                    </form>
+                </li>
+            </div>
+        </header>
+        <hr>
+    </div>
+</script>
+
+<script type="text/template" id="write-comment-template-no-upload-file">
+    <div class="one-comment mdl-color-text--grey-700">
+        <header class="comment__header">
+            <img class="comment__avatar2" height="48" width="48"
+                 src="https://avatars2.githubusercontent.com/u/520500?v=3&s=140" alt="javajigi">
+            <div style="width: 100%;" class="comment-body">
+                <span class="comment__author">
+                    <strong>
+                        <a>{0}</a>
+                        <br>
+                        <span class="comment-contents">{1} &nbsp;{4}</span>
                     </strong>
                 </span>
                 <li>
@@ -181,9 +221,10 @@
                 <span class="comment__author">
                     <strong>
                         <a>{0}</a>
-                        <span class="comment-contents">{1}          {4}</span>
-                        </strong>
-                        </span>
+                        <br>
+                        <span class="comment-contents">{1} &nbsp;{4}</span>
+                    </strong>
+                </span>
                 <li>
                     <form style="display: inline;" action="/api/issues/{2}/comments/{3}" class="edit-comment" method="get">
                         <button type="submit" class="edit-comment-btn">edit</button>
@@ -195,7 +236,6 @@
                         <button type="submit" class="delete-comment-btn">delete</button>
                     </form>
                 </li>
-            </div>
         </header>
     </div>
 </script>
@@ -204,7 +244,7 @@
     <form action="/api/issues/1/uploadFile" enctype="multipart/form-data" method="POST">
         <div style="margin:10px;">
             <input type="file" name="file" id="temp"/>
-            <button class="mdl-button" type="submit">upload file</button>
+            <button class="upload-button" type="submit">upload file</button>
         </div>
     </form>
     <div class="mdl-color-text--primary-contrast mdl-card__supporting-text new-comment">

--- a/src/test/java/codesquad/web/api/ApiAttachmentAcceptanceTest.java
+++ b/src/test/java/codesquad/web/api/ApiAttachmentAcceptanceTest.java
@@ -1,0 +1,37 @@
+package codesquad.web.api;
+
+import codesquad.domain.issue.File;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
+import support.test.AcceptanceTest;
+import support.test.HtmlFormDataBuilder;
+
+import static org.junit.Assert.assertEquals;
+
+public class ApiAttachmentAcceptanceTest extends AcceptanceTest {
+    private static final Logger log = LoggerFactory.getLogger(ApiAttachmentAcceptanceTest.class);
+
+    @Test
+    public void download() throws Exception {
+        ResponseEntity<FileSystemResource> result = basicAuthTemplate().getForEntity("/api/issues/1/attachments/1", FileSystemResource.class);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+        log.debug("body!!!!!!!!!!!!!!!! : {}", result.getBody());
+    }
+
+    @Test
+    public void upload() throws Exception {
+        HttpEntity<MultiValueMap<String, Object>> request = HtmlFormDataBuilder
+                .multipartFormData()
+                .addParameter("file", new ClassPathResource("logback.xml"))
+                .build();
+        ResponseEntity<File> result = basicAuthTemplate().postForEntity("/api/issues/1/attachments", request, File.class);
+        assertEquals(HttpStatus.OK, result.getStatusCode());
+    }
+}

--- a/src/test/java/support/test/HtmlFormDataBuilder.java
+++ b/src/test/java/support/test/HtmlFormDataBuilder.java
@@ -50,7 +50,7 @@ public class HtmlFormDataBuilder {
 
     public static HtmlFormDataBuilder multipartFormData() {
         HttpHeaders headers = new HttpHeaders();
-        headers.setAccept(Arrays.asList(MediaType.TEXT_HTML));
+//        headers.setAccept(Arrays.asList(MediaType.TEXT_HTML));
         headers.setContentType(MediaType.MULTIPART_FORM_DATA);
         return new HtmlFormDataBuilder(headers);
     }


### PR DESCRIPTION
ajax기반 업로드, 다운로드 기능을 추가하였습니다.
파일 업로드 후, 댓글 작성을 하여 첨부파일과 댓글을 동시에 달 수 있도록 구현하였습니다.
그 과정에서 ajax가 필요하다고 생각하여, 업로드 부분은 ajax기반으로 구현하였습니다.
또한 댓글과 첨부파일간의 엔티티 매핑을 할때, OneToOne관계이다 보니, 단방향으로 할지, 양방향으로 할지 고민이 많았습니다.(JPA 학습이 절대적으로 필요한 것 같습니다.) 
일단, 댓글이 첨부파일을 포함하고 있기 때문에, 댓글을 주인으로하여 단방향 매핑을 해야겠다고 생각했습니다. (사실 이게 맞는 생각인지 모르겠습니다.)
또한, 미션을 하면서 궁금한 점이 있습니다. 첨부파일을 삭제할때, 파일 엔티티에도 deleted라는 상태값을 가지도록하여 원본 데이터는 살린채, 화면에만 보여주지 않도록 구현하는게 맞나요?
첨부파일은 용량이 크기때문에 삭제할때, 원본 데이터도 삭제하도록 하는게 맞지 않나 생각했습니다. 실제 현업에서는 어떻게 하는지 궁금합니다.
감사합니다.